### PR TITLE
Page Talks & Posters removed from tab Research. The page itself shoul…

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -56,11 +56,11 @@
   parent = "research"
   weight = 20
 
-[[main]]
-  name = "Talks & Posters"
-  url = "talk"
-  parent = "research"
-  weight = 30
+#[[main]]
+#  name = "Talks & Posters"
+#  url = "talk"
+#  parent = "research"
+#  weight = 30
 
 
 [[main]]


### PR DESCRIPTION
…d still be directly addressable. Just the menu entry is removed.